### PR TITLE
Fixed bug where persistantTimeout wasn't being set.

### DIFF
--- a/src/client.php
+++ b/src/client.php
@@ -151,7 +151,7 @@ class Client extends \SoapClient {
         if($timeoutInSeconds < 0) {
             throw new \Exception('Persistance timeout must be a positive integer or 0 to disable.');
         } else {
-            $this->persistanceFactor = $timeoutInSeconds;
+            $this->persistanceTimeout = $timeoutInSeconds;
         }
         
         return $this;


### PR DESCRIPTION
Tested using xdebug against a wiremock server.

Set wiremock stub with a 20 second timeout and the client now successfully times out on the inputted timeout from __construct on the curl_exec line.

Very useful class!
