### PR TITLE
Change default Content-Type to a valid MIME type.

### DIFF
--- a/src/client.php
+++ b/src/client.php
@@ -273,7 +273,7 @@ class Client extends \SoapClient {
             curl_setopt($ch, CURLOPT_POSTFIELDS, $request);
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->negotiationTimeout);
             curl_setopt($ch, CURLOPT_TIMEOUT, $this->persistanceTimeout);
-            $defaultHeaders = array("Content-Type"=>"type/application-xml");
+            $defaultHeaders = array("Content-Type"=>"text/xml");
             $headers = array_merge($defaultHeaders,$this->customHeaders);
             $headersFormatted = array();
             foreach($headers as $header => $value)


### PR DESCRIPTION
I do not know the MIME type "type/application-xml" and I discovered that there is at least one type of SOAP server software that requires a valid XML MIME type set to work.
