### PR TITLE
Fix request retrying and error handling.

### DIFF
--- a/src/client.php
+++ b/src/client.php
@@ -350,14 +350,14 @@ class Client extends \SoapClient {
             $response = curl_exec($ch);
             $errno = curl_errno($ch);
             curl_close($ch);
-            if($errno !== 0 && $attempt >= $this->persistanceFactor -1) {
-                throw new \Exception('Request failed for the maximum number of attempts.');
-            } else {
+            if (($errno === 0) && ($response !== false)) {
                 break;
+            }
+            if ($attempt >= $this->persistanceFactor - 1) {
+                throw new \Exception('Request failed for the maximum number of attempts.');
             }
         }
         return $response;
     }
 
 }
-


### PR DESCRIPTION
There were two problems with request handling:
1. I've seen situations where curl_exec() returns false but curl_errno() returns 0. Error handling was performed only when $errno was something else than 0. This means that false is returned, and PHP's SoapClient complains about __doRequest() not returning a string.

Fix this by checking both $errno and $response for erroneous values.
1. Request retrying was not working properly because if $attempt had not yet reached the persistance factor, the code would simply break out of the for loop on the first error.

Fix this by only breaking out of the loop if we got a valid response.
